### PR TITLE
In ruby 2.4+ Fixnum is deprecated, change to Integer

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -354,10 +354,11 @@ module VIM
   def self.zero?(var)
     # In Vim 7.2 and older, VIM::evaluate returns Strings for boolean
     # expressions; in later versions, Fixnums.
+    # In ruby 2.4+ Fixnum is deprecated, change to Integer
     case var
     when String
       var == "0"
-    when Fixnum
+    when Integer
       var == 0
     else
       LustyE::assert(false, "unexpected type: #{var.class}")


### PR DESCRIPTION
This patch changes the now deprecated `Fixnum` to `Integer` and stops this error message in vim startup:

`eval:30: warning: constant ::Fixnum is deprecated
`

It works properly with ruby `2.4.0p0`.  I also did some quick testing and it seems to be compatible with ruby versions `2.3.1`, `2.2.4`, `2.1.8`, `1.9.3`, `1.8.7`.